### PR TITLE
Code does not show difference in using "lock"

### DIFF
--- a/docs/csharp/language-reference/keywords/codesnippet/CSharp/lock-statement_2.cs
+++ b/docs/csharp/language-reference/keywords/codesnippet/CSharp/lock-statement_2.cs
@@ -65,5 +65,9 @@
             {
                 threads[i].Start();
             }
+            
+            //block main thread until all other threads have ran to completion.
+            foreach (var t in threads)
+                t.Join();
         }
     }


### PR DESCRIPTION
Originally, did not wait for all threads to complete. As a result, not able to see the expected output when using the lock statement and not using the lock statement (in this scenario).

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
